### PR TITLE
Disable page archiver

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -7,9 +7,9 @@ require 'pry'
 require 'require_all'
 require_rel 'lib'
 
-# require 'open-uri/cached'
-# OpenURI::Cache.cache_path = '.cache'
-require 'scraped_page_archive/open-uri'
+require 'open-uri/cached'
+OpenURI::Cache.cache_path = '.cache'
+# require 'scraped_page_archive/open-uri'
 
 def noko_for(url)
   Nokogiri::HTML(open(url).read)


### PR DESCRIPTION
The scraper is failing to run on morph. Disabling using scraped_by_archiver as a temporary fix.

@tmtmtmtm Could you re-run the scraper please?
